### PR TITLE
Rebuild for libgrpc158_libprotobuf4243

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,7 +17,7 @@ docker_image:
 libabseil:
 - '20230802'
 libprotobuf:
-- 4.23.4
+- 4.24.3
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -21,7 +21,7 @@ docker_image:
 libabseil:
 - '20230802'
 libprotobuf:
-- 4.23.4
+- 4.24.3
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -17,7 +17,7 @@ docker_image:
 libabseil:
 - '20230802'
 libprotobuf:
-- 4.23.4
+- 4.24.3
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/migrations/libgrpc158_libprotobuf4243.yaml
+++ b/.ci_support/migrations/libgrpc158_libprotobuf4243.yaml
@@ -1,0 +1,16 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  exclude:
+    # this shouldn't attempt to modify the python feedstocks
+    - protobuf
+libgrpc:
+- "1.58"
+libprotobuf:
+- 4.24.3
+# already covered by libabseil20230802_libgrpc157_libprotobuf4234,
+# which we cannot delete yet, but keep for clarity
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+- "10.13"                  # [osx and x86_64]
+migrator_ts: 1695803907.2958245

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,11 +11,11 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 libabseil:
 - '20230802'
 libprotobuf:
-- 4.23.4
+- 4.24.3
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,11 +11,11 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 libabseil:
 - '20230802'
 libprotobuf:
-- 4.23.4
+- 4.24.3
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,10 @@ pkgs_dirs:
 
 CONDARC
 
-
-mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
+mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -12,7 +12,7 @@ function startgroup {
             echo "##[group]$1";;
         travis )
             echo "$1"
-            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:start:'"${1// /}"'\r';;
         github_actions )
             echo "::group::$1";;
         * )
@@ -28,7 +28,7 @@ function endgroup {
         azure )
             echo "##[endgroup]";;
         travis )
-            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:end:'"${1// /}"'\r';;
         github_actions )
             echo "::endgroup::";;
     esac

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,10 +23,10 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
+mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - patches/0002-Build-with-native-dependencies.patch
       - patches/0003-Match-version-of-protobuf-java-with-libprotobuf.patch
       - patches/0004-use-C-17.patch
-      - patches/0005-Link-to-abseil-libraries.patch  # [libprotobuf != "3.21"]
+      - patches/0005-Link-to-abseil-libraries.patch
 
   - url: {{ base_url }}/{{ version }}/bazel_nojdk-{{ version }}-darwin-x86_64  # [build_platform == "osx-64"]
     sha256: 574ad4b7ba6615728d0b87f81ee05cf845f58cd8d2e1609cac9124f0eb2d9543  # [build_platform == "osx-64"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
     fn: bazel  # [build_platform == "linux-64"]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
Necessary for https://github.com/conda-forge/bazel-feedstock/pull/207, but the bot doesn't count build tools in the DAG