### PR TITLE
[6.x] rebuild for new protobuf

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,9 +5,9 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.12'
+- '2.17'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -21,7 +21,7 @@ docker_image:
 libabseil:
 - '20240116'
 libprotobuf:
-- 4.25.3
+- 5.27.2
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -25,7 +25,7 @@ docker_image:
 libabseil:
 - '20240116'
 libprotobuf:
-- 4.25.3
+- 5.27.2
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -21,7 +21,7 @@ docker_image:
 libabseil:
 - '20240116'
 libprotobuf:
-- 4.25.3
+- 5.27.2
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/migrations/libgrpc_libprotobuf.yaml
+++ b/.ci_support/migrations/libgrpc_libprotobuf.yaml
@@ -1,0 +1,11 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libgrp 1.63 & libprotobuf 5.27.2
+  kind: version
+  paused: true
+  migration_number: 1
+libgrpc:
+- "1.63"
+libprotobuf:
+- 5.27.2
+migrator_ts: 1711628174.9404116

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 libabseil:
 - '20240116'
 libprotobuf:
-- 4.25.3
+- 5.27.2
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 libabseil:
 - '20240116'
 libprotobuf:
-- 4.25.3
+- 5.27.2
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     fn: bazel                                                                   # [build_platform == "linux-64"]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
Necessary to unblock https://github.com/conda-forge/protobuf-feedstock/pull/215, since this now wants to be built by bazel