### PR TITLE
[6.x] Rebuild for libabseil 20250512 & libprotobuf 6.31.1

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -19,9 +19,9 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libabseil:
-- '20250127'
+- '20250512'
 libprotobuf:
-- 5.29.3
+- 6.31.1
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -19,9 +19,9 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libabseil:
-- '20250127'
+- '20250512'
 libprotobuf:
-- 5.29.3
+- 6.31.1
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -19,9 +19,9 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libabseil:
-- '20250127'
+- '20250512'
 libprotobuf:
-- 5.29.3
+- 6.31.1
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/migrations/absl_grpc_proto_25Q2.yaml
+++ b/.ci_support/migrations/absl_grpc_proto_25Q2.yaml
@@ -1,0 +1,24 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libabseil 20250512, libgrpc 1.73 & libprotobuf 6.31.1
+  kind: version
+  migration_number: 1
+  paused: true
+  exclude:
+    - abseil-cpp
+    - grpc-cpp
+    - libprotobuf
+    - protobuf
+    - re2
+libabseil:
+- 20250512
+libgrpc:
+- "1.73"
+libprotobuf:
+- 6.31.1
+# we need to leave this migration open until we're ready to move the global baseline, see
+# https://github.com/conda-forge/conda-forge.github.io/issues/2467; grpc 1.72 requires 11.0,
+# see https://github.com/grpc/grpc/commit/f122d248443c81592e748da1adb240cbf0a0231c
+c_stdlib_version:   # [osx]
+  - 11.0            # [osx]
+migrator_ts: 1748506837.6039238

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.14'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.14'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -19,9 +19,9 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 libprotobuf:
-- 5.29.3
+- 6.31.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -19,9 +19,9 @@ cxx_compiler:
 cxx_compiler_version:
 - '18'
 libabseil:
-- '20250127'
+- '20250512'
 libprotobuf:
-- 5.29.3
+- 6.31.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,38 +70,43 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
     p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
+    p.add_argument(
         "--debug",
         action="store_true",
         help="Setup debug environment using `conda debug`",
     )
-    p.add_argument(
-        "--output-id", help="If running debug, specify the output to setup."
-    )
+    p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 
     ns = p.parse_args(args=args)
     verify_config(ns)
@@ -104,10 +119,10 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
-        recipe_license_file = os.path.join(
-            "recipe", "recipe-scripts-license.txt"
-        )
+        recipe_license_file = os.path.join("recipe", "recipe-scripts-license.txt")
         if os.path.exists(recipe_license_file):
             os.remove(recipe_license_file)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     fn: bazel                                                                   # [build_platform == "linux-64"]
 
 build:
-  number: 6
+  number: 7
   skip: true  # [win]
 
 requirements:

--- a/recipe/patches/0002-Build-with-native-dependencies.patch
+++ b/recipe/patches/0002-Build-with-native-dependencies.patch
@@ -30,8 +30,8 @@ index b7f17ad5fd..c015de0717 100644
 -    patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
 +    path = "./third_party/systemlibs",
 +    build_file = "./third_party/systemlibs/protobuf.BUILD",
-+)
-+
+ )
+ 
 +RULES_JVM_EXTERNAL_TAG = "4.0"
 +RULES_JVM_EXTERNAL_SHA = "31701ad93dbfe544d597dbe62c9a1fdd76d81d8a9150c2bf1ecf928ecdf97169"
 +
@@ -40,8 +40,8 @@ index b7f17ad5fd..c015de0717 100644
 +    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
 +    sha256 = RULES_JVM_EXTERNAL_SHA,
 +    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
- )
- 
++)
++
 +load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
 +
 +rules_jvm_external_deps()

--- a/recipe/patches/0005-Link-to-abseil-libraries.patch
+++ b/recipe/patches/0005-Link-to-abseil-libraries.patch
@@ -1,4 +1,4 @@
-From 8845c239d6ba0202028c85f17c79a5d8833d5ae9 Mon Sep 17 00:00:00 2001
+From dc39e46ec31e7353fe8550b31a19f64211fcbd39 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Tue, 13 Jun 2023 15:55:49 +0200
 Subject: [PATCH 5/6] Link to abseil libraries
@@ -9,7 +9,7 @@ Co-Authored-By: Silvio Traversaro <silvio@traversaro.it>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/third_party/systemlibs/protobuf.BUILD b/third_party/systemlibs/protobuf.BUILD
-index 3e42a1bf31..18c8a8fb02 100644
+index 3e42a1bf31..47fbb7375d 100644
 --- a/third_party/systemlibs/protobuf.BUILD
 +++ b/third_party/systemlibs/protobuf.BUILD
 @@ -62,19 +62,19 @@ genrule(
@@ -17,14 +17,14 @@ index 3e42a1bf31..18c8a8fb02 100644
  cc_library(
      name = "protobuf",
 -    linkopts = ["-lprotobuf"],
-+    linkopts = ["-lprotobuf", "-labsl_cord", "-labsl_cord_internal", "-labsl_cordz_functions", "-labsl_cordz_handle", "-labsl_cordz_info", "-labsl_cordz_sample_token", "-labsl_log_entry", "-labsl_log_flags", "-labsl_log_globals", "-labsl_log_initialize", "-labsl_log_internal_check_op", "-labsl_log_internal_conditions", "-labsl_log_internal_format", "-labsl_log_internal_globals", "-labsl_log_internal_log_sink_set", "-labsl_log_internal_message", "-labsl_log_internal_nullguard", "-labsl_log_internal_proto", "-labsl_log_severity", "-labsl_log_sink"],
++    linkopts = ["-lprotobuf", "-labsl_cord", "-labsl_cord_internal", "-labsl_cordz_functions", "-labsl_cordz_handle", "-labsl_cordz_info", "-labsl_cordz_sample_token", "-labsl_log_flags", "-labsl_log_globals", "-labsl_log_initialize", "-labsl_log_internal_check_op", "-labsl_log_internal_conditions", "-labsl_log_internal_format", "-labsl_log_internal_globals", "-labsl_log_internal_log_sink_set", "-labsl_log_internal_message", "-labsl_log_internal_nullguard", "-labsl_log_internal_proto", "-labsl_log_severity", "-labsl_log_sink"],
      visibility = ["//visibility:public"],
  )
  
  cc_library(
      name = "protobuf_headers",
 -    linkopts = ["-lprotobuf"],
-+    linkopts = ["-lprotobuf", "-labsl_cord", "-labsl_cord_internal", "-labsl_cordz_functions", "-labsl_cordz_handle", "-labsl_cordz_info", "-labsl_cordz_sample_token", "-labsl_log_entry", "-labsl_log_flags", "-labsl_log_globals", "-labsl_log_initialize", "-labsl_log_internal_check_op", "-labsl_log_internal_conditions", "-labsl_log_internal_format", "-labsl_log_internal_globals", "-labsl_log_internal_log_sink_set", "-labsl_log_internal_message", "-labsl_log_internal_nullguard", "-labsl_log_internal_proto", "-labsl_log_severity", "-labsl_log_sink"],
++    linkopts = ["-lprotobuf", "-labsl_cord", "-labsl_cord_internal", "-labsl_cordz_functions", "-labsl_cordz_handle", "-labsl_cordz_info", "-labsl_cordz_sample_token", "-labsl_log_flags", "-labsl_log_globals", "-labsl_log_initialize", "-labsl_log_internal_check_op", "-labsl_log_internal_conditions", "-labsl_log_internal_format", "-labsl_log_internal_globals", "-labsl_log_internal_log_sink_set", "-labsl_log_internal_message", "-labsl_log_internal_nullguard", "-labsl_log_internal_proto", "-labsl_log_severity", "-labsl_log_sink"],
      visibility = ["//visibility:public"],
  )
  

--- a/recipe/patches/0006-Remove-fdopen-defines-in-zutil.h.patch
+++ b/recipe/patches/0006-Remove-fdopen-defines-in-zutil.h.patch
@@ -1,4 +1,4 @@
-From 00f04c4cd2cc35a8384275a6064fb50eb4ed8175 Mon Sep 17 00:00:00 2001
+From 3d4390876226b7be345e6941933857ba078df320 Mon Sep 17 00:00:00 2001
 From: Mark Adler <madler@alumni.caltech.edu>
 Date: Tue, 12 Dec 2023 22:19:05 -0600
 Subject: [PATCH 6/6] Remove fdopen #defines in zutil.h.


### PR DESCRIPTION
Ray and tensorflow are still using bazel 6. Looks like there are no [other users](https://github.com/search?q=org%3Aconda-forge%20%2Fbazel.*6%2F%20path%3Arecipe%2F*.yaml&type=code) left.

Backport (morally speaking) of #109

